### PR TITLE
fix map names and event structures

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,9 +197,9 @@ func main() {
 		}
 	}()
 
-	b.PollStart("tcp_event_v4", channelV4)
-	b.PollStart("tcp_event_v6", channelV6)
+	b.PollStart("tcp_event_ipv4", channelV4)
+	b.PollStart("tcp_event_ipv6", channelV6)
 	<-sig
-	b.PollStop("tcp_event_v4")
-	b.PollStop("tcp_event_v6")
+	b.PollStop("tcp_event_ipv4")
+	b.PollStop("tcp_event_ipv6")
 }


### PR DESCRIPTION
We are changing the name of the event map in https://github.com/kinvolk/tcptracer-bpf/blob/alessandro/tcp-state/tcptracer-bpf.c

This should be merged at the same time of https://github.com/kinvolk/tcptracer-bpf/pull/13