### PR TITLE
[WIP] Running tests in Semaphore

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,10 @@
+FROM fedora:24
+
+RUN dnf install -y llvm clang kernel-devel make golang
+
+RUN mkdir -p /src /go/src/github.com/kinvolk/
+RUN ln -s /src /go/src/github.com/kinvolk/gobpf-elf-loader
+ENV GOPATH=/go
+
+WORKDIR /src
+

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -xe
+
+RKT_IMAGE=quay.io/alban/rkt:ebpf
+docker pull ${RKT_IMAGE}
+CONTAINER_ID=$(docker run -d ${RKT_IMAGE} /bin/false 2>/dev/null || true)
+docker export -o rkt.tgz ${CONTAINER_ID}
+mkdir -p rkt
+tar xvf rkt.tgz -C rkt/
+
+EBPF_IMAGE=kinvolk/tcptracer-bpf:iaguis-guess-offsets
+docker pull ${EBPF_IMAGE}
+CONTAINER_ID=$(docker run -d ${EBPF_IMAGE} /bin/false 2>/dev/null || true)
+docker export -o ebpf.tgz ${CONTAINER_ID}
+mkdir -p ebpf
+tar xvf ebpf.tgz -C ebpf/
+
+sudo docker build -t gobpf-elf-loader-builder -f Dockerfile.builder .
+sudo docker run --rm \
+	-v $PWD:/src \
+	--entrypoint=/bin/bash \
+	gobpf-elf-loader-builder \
+	-c 'go build -o gobpf-elf-loader'
+sudo chown -R $UID:$UID gobpf-elf-loader
+
+sudo timeout --foreground --kill-after=10 5m \
+	./rkt/rkt \
+        run --interactive \
+        --insecure-options=image,all-run \
+        --dns=8.8.8.8 \
+        --stage1-path=./rkt/stage1-kvm.aci \
+        --volume=ebpf,kind=host,source=$PWD \
+        docker://debian \
+        --mount=volume=ebpf,target=/ebpf \
+        --exec=/bin/sh -- -c \
+        'cd /ebpf ; \
+                mount -t tmpfs tmpfs /tmp ; \
+                mount -t debugfs debugfs /sys/kernel/debug/ ; \
+                ./gobpf-elf-loader ./ebpf/ebpf/fedora/x86_64/4.8.13-200.fc24.x86_64/ebpf.o'
+


### PR DESCRIPTION
Based on @iaguis' guess-offsets branch (https://github.com/kinvolk/gobpf-elf-loader/pull/9).

Since Semaphore's kernel is too old, I am using rkt + kvm flavor with this patch https://github.com/coreos/rkt/pull/3487 to be able to run the ebpf/kprobes.

I can see the following results in Semaphore: https://semaphoreci.com/alban/gobpf-elf-loader/branches/alban-semaphore/builds/4. There is no real tests yet, but that's a proof-of-concept showing we can run ebpf tests in Semaphore.
```
Listening on 127.0.0.2:9091
offsetSaddr found: 4
offsetDaddr found: 0
offsetSport found: 14
offsetDport found: 12
offsetNetns found: 48
offsetDaddrIPv6 found: 56
offsetIno found: 144
offsetFamily found: 16
Ready.
```

@schu Could iovisor/gobpf grow some unit tests in Semaphore using similar technique? (we would need to gather the kernel headers used for building rkt-kvm since iovisor/gobpf is not supposed to do this kind of offset-guessing magic)

/cc @iaguis @alepuccetti @schu 
